### PR TITLE
Handle app detail requests with multiple app ids

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -17,7 +17,7 @@ function app (opts) {
   })
   .then(common.request)
   .then(JSON.parse)
-  .then((res) => common.cleanApp(res.results[0]));
+  .then((res) => common.cleanAppsArray(res.results));
 }
 
 module.exports = common.memoize(app);

--- a/lib/common.js
+++ b/lib/common.js
@@ -41,6 +41,11 @@ function cleanApp (app) {
   };
 }
 
+function cleanAppsArray (apps) {
+    return apps.map(cleanApp)
+}
+
+
 // TODO add an optional parse function
 function request (url, headers) {
   return new Promise(function (resolve, reject) {
@@ -72,5 +77,5 @@ function memoize (fn) {
   });
 }
 
-module.exports = {cleanApp, request, memoize};
+module.exports = {cleanAppsArray, cleanApp, request, memoize};
 


### PR DESCRIPTION
This adds support for requests of the form:

```
 https://itunes.apple.com/lookup?id=542557212,1024818709,600093661,378080432,350027738
```

Apple seems to return valid results for up to 200 app ids.
