### PR TITLE
safe cleanList when no feed entries

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -6,7 +6,7 @@ const c = require('./constants');
 const R = require('ramda');
 
 const cleanList = (results) =>
-  results.feed.entry.slice(1).map((review) => ({
+  results.feed.entry ? results.feed.entry.slice(1).map((review) => ({
     id: review.id.label,
     userName: review.author.name.label,
     userUrl: review.author.uri.label,
@@ -15,7 +15,7 @@ const cleanList = (results) =>
     title: review.title.label,
     text: review.content.label,
     url: review.link.attributes.href
-  }));
+  })) : [];
 
 const reviews = (opts) => new Promise((resolve) => {
   validate(opts);


### PR DESCRIPTION
If you request a page for which there are no reviews (e.g., app has 90 reviews with 50 per page and you ask for page 3), this function previously would throw:

```
TypeError: Cannot read property 'slice' of undefined
    at results.feed.entry.slice.map (/node_modules/app-store-scraper/lib/reviews.js:9:21)
    at process._tickCallback (node.js:368:9)
```