### PR TITLE
Fix review lookup promise chain

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -62,7 +62,7 @@ const reviews = (opts) => new Promise((resolve) => {
   if (opts.id) {
     resolve(opts.id);
   } else if (opts.appId) {
-    app(opts).then((app) => resolve(app.id));
+    resolve(app(opts).then(app => app.id));
   }
 })
   .then((id) => {


### PR DESCRIPTION
Fix the promise chain for review lookups that need to look up the app details first.

This allows error handling for cases where the app is not found or an error occurs with the lookup.