### PR TITLE
Set memoize to false by default and offer option to configure it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ coverage
 # node-waf configuration
 .lock-wscript
 
+#vim swap files
+*.swp
+*.swo
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 

--- a/README.md
+++ b/README.md
@@ -292,9 +292,25 @@ Returns:
 
 By default all methods are not [memoized](https://github.com/medikoo/memoizee) which means the results are not cached.
 
-By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments. The cached values are set to expire every 12 hours, refreshes the data once per day.
+By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments.
 
-In case you want to cache the results, you can pass `cache: true` to any method. But, in case you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's false by default:
+In case you want to cache the results, you can pass `cache: true`, or your own cache configuration object to any method. With the simple `cache: true` a default configuration (see below) will be used, and the cached values are set to expire every 12 hours.
+
+But, if you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's `false` by default:
+
+See the default object configuration used in case of `cache: true`:
+
+```js
+{
+  primitive: true,
+  normalizer: JSON.stringify,
+  maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
+  max: 1000 // save up to 1k results to avoid memory issues
+}
+```
+More information about all arguments available, you can find [here](https://github.com/medikoo/memoizee).
+
+Examples of usage:
 
 ```js
 const store = require('app-store-scraper');
@@ -302,11 +318,11 @@ const store = require('app-store-scraper');
 // This request will hit the store and won't cache the results.
 store.search({term: "panda"}).then(console.log);
 
-// force to cache results (memoizing).
+// force to cache results (memoizing) using the default configuration.
 store.search({term: "panda", cache: true}).then(console.log);
 
-// second call will return cached results.
-store.search({term: "panda", cache: true}).then(console.log);
+// force to cache results for only 1 hour.
+store.search({term: "panda", cache: {maxAge: 1000 * 60 * 60}}).then(console.log);
 ```
 
 If you are interested in seeing how may requests are being done, you can run

--- a/README.md
+++ b/README.md
@@ -287,3 +287,28 @@ Returns:
   (...)
 ]
 ```
+
+## Memoization
+
+By default all methods are not [memoized](https://github.com/medikoo/memoizee) which means the results are not cached.
+
+By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments. The cached values are set to expire every 12 hours, refreshes the data once per day.
+
+In case you want to cache the results, you can pass `cache: true` to any method. But, in case you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's false by default:
+
+```js
+const store = require('app-store-scraper');
+
+// This request will hit the store and won't cache the results.
+store.search({term: "panda"}).then(console.log);
+
+// force to cache results (memoizing).
+store.search({term: "panda", cache: true}).then(console.log);
+
+// second call will return cached results.
+store.search({term: "panda", cache: true}).then(console.log);
+```
+
+If you are interested in seeing how may requests are being done, you can run
+your node program with `DEBUG=app-store-scraper`.
+

--- a/lib/common.js
+++ b/lib/common.js
@@ -68,7 +68,7 @@ function memoize (fn) {
   });
 
   return function(opts) {
-    if (opts.cache !== false) {
+    if (opts.cache === true) {
       return memoized(opts);
     }
     return fn(opts);

--- a/lib/common.js
+++ b/lib/common.js
@@ -59,7 +59,7 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
   });
 });
 
-function memoize(fn) {
+function memoize (fn) {
   const memoizeeDefaults = {
     primitive: true,
     normalizer: JSON.stringify,
@@ -67,7 +67,7 @@ function memoize(fn) {
     max: 1000 // save up to 1k results to avoid memory issues
   };
 
-  return function(opts) {
+  return function (opts) {
     if (opts.cache === true) {
       const memoized = memoizee(fn, memoizeeDefaults);
       return memoized(opts);
@@ -75,7 +75,7 @@ function memoize(fn) {
 
     if (typeof opts.cache === 'object') {
       const memoized = memoizee(fn, opts.cache);
-      return memoized(opts)
+      return memoized(opts);
     }
     return fn(opts);
   };

--- a/lib/common.js
+++ b/lib/common.js
@@ -60,11 +60,19 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
 });
 
 function memoize (fn) {
-  return memoizee(fn, {
+  const memoized = memoizee(fn, {
     primitive: true,
     normalizer: JSON.stringify,
-    maxAge: 1000 * 60 * 60 * 12 // cache for 12 hours
+    maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
+    max: 1000 // save up to 1k results to avoid memory issues
   });
+
+  return function(opts) {
+    if (opts.cache !== false) {
+      return memoized(opts);
+    }
+    return fn(opts);
+  };
 }
 
 module.exports = {cleanApp, request: doRequest, memoize};

--- a/lib/common.js
+++ b/lib/common.js
@@ -59,17 +59,23 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
   });
 });
 
-function memoize (fn) {
-  const memoized = memoizee(fn, {
+function memoize(fn) {
+  const memoizeeDefaults = {
     primitive: true,
     normalizer: JSON.stringify,
     maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
     max: 1000 // save up to 1k results to avoid memory issues
-  });
+  };
 
   return function(opts) {
     if (opts.cache === true) {
+      const memoized = memoizee(fn, memoizeeDefaults);
       return memoized(opts);
+    }
+
+    if (typeof opts.cache === 'object') {
+      const memoized = memoizee(fn, opts.cache);
+      return memoized(opts)
     }
     return fn(opts);
   };


### PR DESCRIPTION
This PR aims to:

- set memoizee to false by default;
- offer the option to pass a configuration object in the arguments, or only the simple cache: true, using the default configuration;
- update the documentation to be compatible with the changes above;
- added vim swap files to .gitignore;

If the code is approved, I'm willing to "replicate" the same changes to google-play-scraper;

Thank you.