### PR TITLE
Set memoization to false by default and allow to use a function to use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ coverage
 # node-waf configuration
 .lock-wscript
 
+#vim swap files
+*.swp
+*.swo
+
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 

--- a/README.md
+++ b/README.md
@@ -292,9 +292,25 @@ Returns:
 
 By default all methods are not [memoized](https://github.com/medikoo/memoizee) which means the results are not cached.
 
-By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments. The cached values are set to expire every 12 hours, refreshes the data once per day.
+By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments.
 
-In case you want to cache the results, you can pass `cache: true` to any method. But, in case you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's false by default:
+In case you want to cache the results, you can pass `cache: true`, or your own cache configuration object to any method. With the simple `cache: true` a default configuration (see below) will be used, and the cached values are set to expire every 12 hours.
+
+But, if you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's `false` by default:
+
+See the default object configuration used in case of `cache: true`:
+
+```js
+{
+  primitive: true,
+  normalizer: JSON.stringify,
+  maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
+  max: 1000 // save up to 1k results to avoid memory issues
+}
+```
+More information about all arguments available, you can find [here](https://github.com/medikoo/memoizee).
+
+Examples of usage:
 
 ```js
 const store = require('app-store-scraper');
@@ -302,11 +318,11 @@ const store = require('app-store-scraper');
 // This request will hit the store and won't cache the results.
 store.search({term: "panda"}).then(console.log);
 
-// force to cache results (memoizing).
+// force to cache results (memoizing) using the default configuration.
 store.search({term: "panda", cache: true}).then(console.log);
 
-// second call will return cached results.
-store.search({term: "panda", cache: true}).then(console.log);
+// force to cache results for only 1 hour.
+store.search({term: "panda", cache: {maxAge: 1000 * 60 * 60}}).then(console.log);
 ```
 
 If you are interested in seeing how may requests are being done, you can run

--- a/README.md
+++ b/README.md
@@ -287,3 +287,28 @@ Returns:
   (...)
 ]
 ```
+
+## Memoization
+
+By default all methods are not [memoized](https://github.com/medikoo/memoizee) which means the results are not cached.
+
+By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments. The cached values are set to expire every 12 hours, refreshes the data once per day.
+
+In case you want to cache the results, you can pass `cache: true` to any method. But, in case you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's false by default:
+
+```js
+const store = require('app-store-scraper');
+
+// This request will hit the store and won't cache the results.
+store.search({term: "panda"}).then(console.log);
+
+// force to cache results (memoizing).
+store.search({term: "panda", cache: true}).then(console.log);
+
+// second call will return cached results.
+store.search({term: "panda", cache: true}).then(console.log);
+```
+
+If you are interested in seeing how may requests are being done, you can run
+your node program with `DEBUG=app-store-scraper`.
+

--- a/README.md
+++ b/README.md
@@ -294,9 +294,11 @@ By default all methods are not [memoized](https://github.com/medikoo/memoizee) w
 
 By enabling memoization, the request and response processing is skipped if a function is called again with the same arguments.
 
-In case you want to cache the results, you can pass `cache: true`, or your own cache configuration object to any method. With the simple `cache: true` a default configuration (see below) will be used, and the cached values are set to expire every 12 hours.
+In case you want to cache the results, you can use the memoized function: `const store = require('app-store-scraper').memoized()`.
 
-But, if you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, you don't need to pass any value to `cache` argument, since it's `false` by default:
+You can also pass your own cache configuration object to the memoized function, if you don't pass it, a default configuration (see below) will be used, and the cached values are set to expire every 12 hours.
+
+But, if you want to force fresh results, want to avoid the cache memory consumption altogether or you're running a simple short lived script, the simple `const store = require('app-store-scraper')` should be enough.
 
 See the default object configuration used in case of `cache: true`:
 
@@ -308,23 +310,25 @@ See the default object configuration used in case of `cache: true`:
   max: 1000 // save up to 1k results to avoid memory issues
 }
 ```
-More information about all arguments available, you can find [here](https://github.com/medikoo/memoizee).
+The `primitive` property will be always `true` by default, the reason for that and more information about all arguments available for memoizee, you can find [here](https://github.com/medikoo/memoizee).
 
 Examples of usage:
 
 ```js
-const store = require('app-store-scraper');
+const store = require('app-store-scraper').memoized();
 
-// This request will hit the store and won't cache the results.
+// The first request will hit the store and cache the results.
 store.search({term: "panda"}).then(console.log);
 
-// force to cache results (memoizing) using the default configuration.
-store.search({term: "panda", cache: true}).then(console.log);
+// This second one will hit the cache directly.
+store.search({term: "panda"}).then(console.log);
 
-// force to cache results for only 1 hour.
-store.search({term: "panda", cache: {maxAge: 1000 * 60 * 60}}).then(console.log);
+// Passing an object to cache results only for 10 seconds.
+const store = require('app-store-scraper').memoized({maxAge: 10000});
+
+// The response for this request will be cached for 10 seconds.
+store.search({term: "panda"}).then(console.log);
 ```
 
-If you are interested in seeing how may requests are being done, you can run
+If you are interested in seeing how may requests are being done and the cache configuration being used, you can run
 your node program with `DEBUG=app-store-scraper`.
-

--- a/index.js
+++ b/index.js
@@ -13,3 +13,4 @@ module.exports.search = require('./lib/search');
 module.exports.suggest = require('./lib/suggest');
 module.exports.similar = require('./lib/similar');
 module.exports.reviews = require('./lib/reviews');
+module.exports.memoized = require('./lib/memoized.js');

--- a/lib/app.js
+++ b/lib/app.js
@@ -26,4 +26,4 @@ function app (opts) {
   });
 }
 
-module.exports = common.memoize(app);
+module.exports = app;

--- a/lib/common.js
+++ b/lib/common.js
@@ -68,7 +68,7 @@ function memoize (fn) {
   });
 
   return function(opts) {
-    if (opts.cache !== false) {
+    if (opts.cache === true) {
       return memoized(opts);
     }
     return fn(opts);

--- a/lib/common.js
+++ b/lib/common.js
@@ -59,7 +59,7 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
   });
 });
 
-function memoize(fn) {
+function memoize (fn) {
   const memoizeeDefaults = {
     primitive: true,
     normalizer: JSON.stringify,
@@ -67,7 +67,7 @@ function memoize(fn) {
     max: 1000 // save up to 1k results to avoid memory issues
   };
 
-  return function(opts) {
+  return function (opts) {
     if (opts.cache === true) {
       const memoized = memoizee(fn, memoizeeDefaults);
       return memoized(opts);
@@ -75,7 +75,7 @@ function memoize(fn) {
 
     if (typeof opts.cache === 'object') {
       const memoized = memoizee(fn, opts.cache);
-      return memoized(opts)
+      return memoized(opts);
     }
     return fn(opts);
   };

--- a/lib/common.js
+++ b/lib/common.js
@@ -60,11 +60,19 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
 });
 
 function memoize (fn) {
-  return memoizee(fn, {
+  const memoized = memoizee(fn, {
     primitive: true,
     normalizer: JSON.stringify,
-    maxAge: 1000 * 60 * 60 * 12 // cache for 12 hours
+    maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
+    max: 1000 // save up to 1k results to avoid memory issues
   });
+
+  return function(opts) {
+    if (opts.cache !== false) {
+      return memoized(opts);
+    }
+    return fn(opts);
+  };
 }
 
 module.exports = {cleanApp, request: doRequest, memoize};

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const request = require('request');
-const memoizee = require('memoizee');
 const debug = require('debug')('app-store-scraper');
 
 function cleanApp (app) {
@@ -59,26 +58,4 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
   });
 });
 
-function memoize (fn) {
-  const memoizeeDefaults = {
-    primitive: true,
-    normalizer: JSON.stringify,
-    maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
-    max: 1000 // save up to 1k results to avoid memory issues
-  };
-
-  return function (opts) {
-    if (opts.cache === true) {
-      const memoized = memoizee(fn, memoizeeDefaults);
-      return memoized(opts);
-    }
-
-    if (typeof opts.cache === 'object') {
-      const memoized = memoizee(fn, opts.cache);
-      return memoized(opts);
-    }
-    return fn(opts);
-  };
-}
-
-module.exports = {cleanApp, request: doRequest, memoize};
+module.exports = {cleanApp, request: doRequest};

--- a/lib/common.js
+++ b/lib/common.js
@@ -59,17 +59,23 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
   });
 });
 
-function memoize (fn) {
-  const memoized = memoizee(fn, {
+function memoize(fn) {
+  const memoizeeDefaults = {
     primitive: true,
     normalizer: JSON.stringify,
     maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
     max: 1000 // save up to 1k results to avoid memory issues
-  });
+  };
 
   return function(opts) {
     if (opts.cache === true) {
+      const memoized = memoizee(fn, memoizeeDefaults);
       return memoized(opts);
+    }
+
+    if (typeof opts.cache === 'object') {
+      const memoized = memoizee(fn, opts.cache);
+      return memoized(opts)
     }
     return fn(opts);
   };

--- a/lib/list.js
+++ b/lib/list.js
@@ -65,4 +65,4 @@ function list (opts) {
   });
 }
 
-module.exports = common.memoize(list);
+module.exports = list;

--- a/lib/memoized.js
+++ b/lib/memoized.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const memoizee = require('memoizee');
+const debug = require('debug')('app-store-scraper');
+
+const memoizeeDefaults = {
+  primitive: true,
+  normalizer: JSON.stringify,
+  maxAge: 1000 * 60 * 60 * 12, // cache for 12 hours
+  max: 1000 // save up to 1k results to avoid memory issues
+};
+
+function memoized (opts) {
+  let module = Object.assign({}, this);
+  let cacheOpts = memoizeeDefaults;
+
+  if (typeof opts === 'object') {
+    opts.primitive = true; // ensure that primitive will be always true
+    cacheOpts = opts;
+  }
+
+  debug('cache configuration being used: %s', JSON.stringify(cacheOpts));
+
+  // it shouldn't be memoized;
+  delete module.memoized;
+
+  for (let prop in module) {
+    if (typeof module[prop] === 'function') {
+      module[prop] = memoizee(module[prop].bind(this), cacheOpts);
+    }
+  }
+
+  return module;
+}
+
+module.exports = memoized;

--- a/lib/memoized.js
+++ b/lib/memoized.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const R = require('ramda');
 const memoizee = require('memoizee');
+const scraper = require('..');
 const debug = require('debug')('app-store-scraper');
 
 const memoizeeDefaults = {
@@ -11,8 +13,14 @@ const memoizeeDefaults = {
 };
 
 function memoized (opts) {
-  let module = Object.assign({}, this);
   let cacheOpts = memoizeeDefaults;
+
+  const memoizeMethods = (val) => {
+    if (typeof val === 'function') {
+      return memoizee(val, cacheOpts);
+    }
+    return val;
+  };
 
   if (typeof opts === 'object') {
     opts.primitive = true; // ensure that primitive will be always true
@@ -21,16 +29,7 @@ function memoized (opts) {
 
   debug('cache configuration being used: %s', JSON.stringify(cacheOpts));
 
-  // it shouldn't be memoized;
-  delete module.memoized;
-
-  for (let prop in module) {
-    if (typeof module[prop] === 'function') {
-      module[prop] = memoizee(module[prop].bind(this), cacheOpts);
-    }
-  }
-
-  return module;
+  return R.mapObjIndexed(memoizeMethods, scraper);
 }
 
 module.exports = memoized;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -76,4 +76,4 @@ const reviews = (opts) => new Promise((resolve) => {
   .then(parseXML)
   .then(extractReviews);
 
-module.exports = common.memoize(reviews);
+module.exports = reviews;

--- a/lib/search.js
+++ b/lib/search.js
@@ -26,4 +26,4 @@ function search (opts) {
   .then((res) => res.results.map(common.cleanApp));
 }
 
-module.exports = common.memoize(search);
+module.exports = search;

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -39,4 +39,4 @@ function similar (opts) {
   });
 }
 
-module.exports = common.memoize(similar);
+module.exports = similar;

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -42,4 +42,4 @@ function suggest (opts) {
   .then(extractSuggestions);
 }
 
-module.exports = common.memoize(suggest);
+module.exports = suggest;


### PR DESCRIPTION
This PR aims to:

1. Set the memoization usage to false by default;

2. Allow to use memoization using a `memoized` function, like this: `const store = require('app-store-scraper').memoized()`, as suggested on my previous pr: [#29](https://github.com/facundoolano/app-store-scraper/pull/29).

It's possible to pass a config object to `memoized` function as well. 
It memoizes each method, so I believe it's easy to extend this to [google-play-scraper](https://github.com/facundoolano/google-play-scraper).

3. Updated the README.md file to be compatible with the changes above.

Thank you. 