### PR TITLE
Added country option to app method options on readme and set its default to "us"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Retrieves the full detail of an application. Options:
 
 * `id`: the iTunes "trackId" of the app, for example `553834731` for Candy Crush Saga. Either this or the `appId` should be provided.
 * `appId`: the iTunes "bundleId" of the app, for example `com.midasplayer.apps.candycrushsaga` for Candy Crush Saga. Either this or the `id` should be provided.
+* `country`: the two letter country code to get the app details from. Defaults to `us`.
 
 Example:
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -10,7 +10,7 @@ function app (opts) {
     }
     const idField = opts.id ? 'id' : 'bundleId';
     const idValue = opts.id || opts.appId;
-    const country = opts.country || '';
+    const country = opts.country || 'us';
     return resolve(`${BASE_URL}?${idField}=${idValue}&country=${country}`);
   })
   .then(common.request)


### PR DESCRIPTION
Whereas the `country` option is already set on the `lib/app.js`  and is sent on the querystring, I set it to `us` by default instead of `""` as it's on the other methods and also added it to the options list on docs, since it wasn't among the shown options for this method.
