### PR TITLE
Fix num default on list method

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -43,8 +43,8 @@ function validate (opts) {
   }
 
   opts.num = opts.num || 50;
-  if (opts.num > 100) {
-    throw Error('Cannot retrieve more than 100 apps at a time');
+  if (opts.num > 200) {
+    throw Error('Cannot retrieve more than 200 apps');
   }
 
   opts.country = opts.country || 'us';

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -37,10 +37,10 @@ describe('List method', () => {
     return store.list({
       category: store.category.GAMES_ACTION,
       collection: store.collection.TOP_FREE_IOS,
-      num: 200
+      num: 250
     })
     .then(assert.fail)
-    .catch((e) => assert.equal(e.message, 'Cannot retrieve more than 100 apps at a time'));
+    .catch((e) => assert.equal(e.message, 'Cannot retrieve more than 200 apps'));
   });
 
   it('should fetch apps with fullDetail', () => {


### PR DESCRIPTION
It sets the `num` default to `200` on `list` method, btw, as it was already written on docs. 