### PR TITLE
WIP: Proper order in search results

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('./common');
-const BASE_URL = 'https://itunes.apple.com/lookup';
 
 function app (opts) {
   return new Promise(function (resolve) {
@@ -10,19 +9,14 @@ function app (opts) {
     }
     const idField = opts.id ? 'id' : 'bundleId';
     const idValue = opts.id || opts.appId;
-    const country = opts.country || 'us';
-    return resolve(`${BASE_URL}?${idField}=${idValue}&country=${country}`);
+    resolve(common.lookup([idValue], idField, opts.country));
   })
-  .then(common.request)
-  .then(JSON.parse)
-  .then((res) => {
-    return new Promise((resolve) => {
-      if (res.results.length === 0) {
-        throw Error('App not found (404)');
-      }
+  .then((results) => {
+    if (results.length === 0) {
+      throw Error('App not found (404)');
+    }
 
-      resolve(common.cleanApp(res.results[0]));
-    });
+    return results[0];
   });
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -2,6 +2,7 @@
 
 const request = require('request');
 const debug = require('debug')('app-store-scraper');
+const c = require('./constants');
 
 function cleanApp (app) {
   return {
@@ -58,4 +59,22 @@ const doRequest = (url, headers) => new Promise(function (resolve, reject) {
   });
 });
 
-module.exports = {cleanApp, request: doRequest};
+const LOOKUP_URL = 'https://itunes.apple.com/lookup';
+
+function lookup (ids, idField, country) {
+  idField = idField || 'id';
+  country = country || 'us';
+  const joinedIds = ids.join(',');
+  const url = `${LOOKUP_URL}?${idField}=${joinedIds}&country=${country}`;
+  return doRequest(url)
+    .then(JSON.parse)
+    .then((res) => res.results.map(cleanApp));
+}
+
+function storeId (countryCode) {
+  const markets = c.markets;
+  const defaultStore = '143441';
+  return (countryCode && markets[countryCode.toUpperCase()]) || defaultStore;
+}
+
+module.exports = {cleanApp, lookup, request: doRequest, storeId};

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,29 +1,60 @@
 'use strict';
 
+const R = require('ramda');
 const common = require('./common');
-const BASE_URL = 'https://itunes.apple.com/search';
-const c = require('./constants');
+const BASE_URL = 'https://itunes.apple.com/WebObjects/MZStore.woa/wa/search?clientApplication=Software&media=software&term=';
 
-// TODO allow override country & language
-// TODO handle not found
+// function search (opts) {
+//   return new Promise(function (resolve) {
+//     if (!opts.term) {
+//       throw Error('term is required');
+//     }
+
+//     const entity = opts.device || c.device.ALL;
+//     const num = opts.num || 50;
+//     let url = `${BASE_URL}?media=software&entity=${entity}&term=${opts.term}&limit=${num}`;
+//     if (opts.country) {
+//       url = url + `&country=${opts.country}`;
+//     }
+//     return resolve(url);
+//   })
+//   .then(common.request)
+//   .then(JSON.parse)
+//   .then((res) => res.results.map(common.cleanApp));
+// }
+
+/*
+ curl -X GET \
+ 'https://itunes.apple.com/WebObjects/MZStore.woa/wa/search?clientApplication=Software&media=software&term=panda' \
+ -H 'accept-language: en-us' \
+ -H 'X-Apple-Store-Front: 143465-19,24 t:native' > resulta.txt
+*/
+
+// FIXME find out how to filter by device or remove option from README
+// TODO establish a max limit for num, and allow to paginate to take more results
+// TODO document country and lang in readme
 
 function search (opts) {
   return new Promise(function (resolve) {
     if (!opts.term) {
       throw Error('term is required');
     }
-
-    const entity = opts.device || c.device.ALL;
+    const url = BASE_URL + opts.term;
+    const storeId = common.storeId(opts.country);
     const num = opts.num || 50;
-    let url = `${BASE_URL}?media=software&entity=${entity}&term=${opts.term}&limit=${num}`;
-    if (opts.country) {
-      url = url + `&country=${opts.country}`;
-    }
-    return resolve(url);
-  })
-  .then(common.request)
-  .then(JSON.parse)
-  .then((res) => res.results.map(common.cleanApp));
+    const lang = opts.lang || 'en-us';
+
+    common.request(url, {
+      'X-Apple-Store-Front': `${storeId},24 t:native`,
+      'Accept-Language': lang
+    })
+    .then(JSON.parse)
+    .then((response) => response.bubbles[0].results)
+    .then(R.take(num))
+    .then(R.pluck('id'))
+    .then((ids) => common.lookup(ids, 'id', opts.country))
+    .then(resolve);
+  });
 }
 
 module.exports = search;

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -2,15 +2,7 @@
 
 const app = require('./app');
 const BASE_URL = 'https://itunes.apple.com/us/app/app/id';
-const LOOKUP_URL = 'https://itunes.apple.com/lookup?id=';
 const common = require('./common.js');
-const c = require('./constants.js');
-
-function storeId (countryCode) {
-  const markets = c.markets;
-  const defaultStore = '143441';
-  return (countryCode && markets[countryCode.toUpperCase()]) || defaultStore;
-}
 
 function similar (opts) {
   return new Promise(function (resolve, reject) {
@@ -23,7 +15,7 @@ function similar (opts) {
     }
   })
   .then((id) => common.request(`${BASE_URL}${id}`, {
-    'X-Apple-Store-Front': `${storeId(opts.country)},32`
+    'X-Apple-Store-Front': `${common.storeId(opts.country)},32`
   }))
   .then(function (text) {
     const index = text.indexOf('customersAlsoBoughtApps');
@@ -33,9 +25,7 @@ function similar (opts) {
 
     const slice = text.slice(index, index + 300).match(/\[(.*)\]/)[0];
     const ids = JSON.parse(slice);
-    return common.request(LOOKUP_URL + ids.join(','))
-      .then(JSON.parse)
-      .then((res) => res.results.map(common.cleanApp));
+    return common.lookup(ids, 'id', opts.country);
   });
 }
 


### PR DESCRIPTION
Fixes #30 

Changed the underlying itunes api used for search, so the results order matches what's seen in the store. 

Still need to update readme and add a pagination parameter (right now any number of results can be fetched, haven't tested at what point it breaks).

@icaroponce @anater @cloforce I would appreciate if you checkout this branch and confirm the results are what you expect according to the discussion in #30.

