### PR TITLE
Handle case when there are no search results

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -29,7 +29,7 @@ function search (opts) {
       'Accept-Language': lang
     })
     .then(JSON.parse)
-    .then((response) => response.bubbles[0].results)
+    .then((response) => (response.bubbles[0] && response.bubbles[0].results) || [])
     .then(paginate(opts.num, opts.page))
     .then(R.pluck('id'))
     .then((ids) => common.lookup(ids, 'id', opts.country))


### PR DESCRIPTION
Currently, the search script bails with an error if there are no results. This change handles that case.