### PR TITLE
Fix list function

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Example:
 var store = require('app-store-scraper');
 
 store.list({
-  collection: store.collection.TOP_FREE_IPAD
+  collection: store.collection.TOP_FREE_IOS
   num: 2
 })
 .then(console.log)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,9 +8,7 @@ const collection = {
 
   NEW_APPS_IOS: 'ios-apps/new-apps-we-love/all',
   NEW_GAMES_IOS: 'ios-apps/new-games-we-love/all',
-  TOP_FREE_IOS: 'ios-apps/top-free/all',
-  TOP_FREE_GAMES_IOS: 'ios-apps/top-free/games',
-  TOP_FREE_IPAD: 'ios-apps/top-free-ipad/all',
+  TOP_FREE_IOS: 'topfreeapplications',
   TOP_GROSSING_IOS: 'ios-apps/top-grossing/all',
   TOP_GROSSING_IPAD: 'ios-apps/top-grossing-ipad/all',
   TOP_PAID_IOS: 'ios-apps/top-paid/all',

--- a/lib/list.js
+++ b/lib/list.js
@@ -14,8 +14,8 @@ function cleanApp (app) {
     url: app.id.label,
     developer: app['im:artist'].label,
     developerUrl: app['im:artist'].attributes.href,
-    genre: [app.category.attributes.term],
-    genreId: [app.category.attributes['im:id']],
+    genre: app.category.attributes.term,
+    genreId: app.category.attributes['im:id'],
     released: app['im:releaseDate'].attributes.label,
     price: app['im:price'].attributes.amount
   };

--- a/lib/list.js
+++ b/lib/list.js
@@ -5,34 +5,30 @@ const common = require('./common');
 const c = require('./constants');
 
 function cleanApp (app) {
-  const genres = app.genres.map((g) => g.name);
-  const genreIds = app.genres.map((g) => g.genreId);
-  // dev id missing in macos apps, parsing from url
-  const developerId = parseInt(app.artistUrl.split(/id/g).pop());
-
   return {
-    id: app.id,
-    appId: app.bundleId,
-    description: app.summary, // only present in mac right now
-    title: app.name,
-    icon: app.artworkUrl100,
-    url: app.url,
-    developer: app.artistName,
-    developerUrl: app.artistUrl,
-    developerId,
-    genres,
-    genreIds,
-    released: app.releaseDate
+    id: app.id.attributes['im:id'],
+    appId: app.id.attributes['im:bundleId'],
+    description: app.summary.label, // only present in mac right now
+    title: app['im:name'].label,
+    icon: app['im:image'][2].label,
+    url: app.id.label,
+    developer: app['im:artist'].label,
+    developerUrl: app['im:artist'].attributes.href,
+    genre: [app.category.attributes.term],
+    genreId: [app.category.attributes['im:id']],
+    released: app['im:releaseDate'].attributes.label,
+    price: app['im:price'].attributes.amount
   };
 }
 
 function processResults (opts) {
   return function (results) {
-    const apps = results.feed.results;
+    const apps = results.feed.entry;
 
     if (opts.fullDetail) {
-      return common.lookup(R.pluck('id', apps), 'id', opts.country, opts.requestOptions);
+      return common.lookup(R.pluck('im:id', apps), 'id', opts.country, opts.requestOptions);
     }
+
     return apps.map(cleanApp);
   };
 }
@@ -56,7 +52,7 @@ function list (opts) {
     opts = R.clone(opts || {});
     validate(opts);
 
-    const url = `https://rss.itunes.apple.com/api/v1/${opts.country}/${opts.collection}/${opts.num}/explicit.json`;
+    const url = `http://ax.itunes.apple.com/WebObjects/MZStoreServices.woa/ws/RSS/${opts.collection}/limit=${opts.num}/json`;
     common.request(url, {}, opts.requestOptions)
       .then(JSON.parse)
       .then(processResults(opts))

--- a/lib/list.js
+++ b/lib/list.js
@@ -5,6 +5,9 @@ const common = require('./common');
 const c = require('./constants');
 
 function cleanApp (app) {
+  // dev id missing in macos apps, parsing from url
+  const developerId = parseInt(app['im:artist'].attributes.href.split(/id/g).pop());
+
   return {
     id: app.id.attributes['im:id'],
     appId: app.id.attributes['im:bundleId'],
@@ -17,7 +20,8 @@ function cleanApp (app) {
     genre: app.category.attributes.term,
     genreId: app.category.attributes['im:id'],
     released: app['im:releaseDate'].attributes.label,
-    price: app['im:price'].attributes.amount
+    price: app['im:price'].attributes.amount,
+    developerId
   };
 }
 

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -52,6 +52,7 @@ describe('List method', () => {
       assert.equal(app.genreId, '6014');
 
       assert.equal(app.price, '0.00000');
+      assert(app.free);
 
       assert.isString(app.developer);
       if (app.developerWebsite) {

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -48,11 +48,10 @@ describe('List method', () => {
     .then((apps) => apps.map((app) => {
       assert.isString(app.description);
 
-      assert.equal(app.genres[0], 'Games');
-      assert.equal(app.genreIds[0], '6014');
+      assert.equal(app.genre, 'Games');
+      assert.equal(app.genreId, '6014');
 
-      assert.equal(app.price, '0');
-      assert(app.free);
+      assert.equal(app.price, '0.00000');
 
       assert.isString(app.developer);
       if (app.developerWebsite) {


### PR DESCRIPTION
This PR updates the list function to pull from a new source, as the RSS feed generator [here](https://rss.itunes.apple.com/en-us) no longer has the option for `software` (i.e. apps). In doing this, a few different things need to change:

1. The format of the  returned `cleanApp` object needed to be updated to match the new source data.
2. Some constants needed to be consolidated as some options are no longer available.
3. `genres` and `genreIds` were updated to `genre` and `genreId` as multiple options are no longer returned.
4. `price` was added to the response.

Let me know if you have any questions or requests!