### PR TITLE
ITunes feed.entry can be object, if app has only one review.

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -6,8 +6,14 @@ const app = require('./app');
 const c = require('./constants');
 
 function cleanList (results) {
-  const reviews = results.feed.entry || [];
-  return reviews.slice(1).map((review) => ({
+  let reviews = results.feed.entry || [];
+  if(!Array.isArray(reviews)) {
+    reviews = [reviews];
+  }
+  else {
+    reviews = reviews.slice(1);
+  }
+  return reviews.map((review) => ({
     id: review.id.label,
     userName: review.author.name.label,
     userUrl: review.author.uri.label,


### PR DESCRIPTION
Hi, seems like Apple can return an object, if application has only one review.
You can test it with app below at this moment.
```
store.reviews({
      id: '1405670215',
      country: 'ru',
      sort: store.sort.RECENT,
      page: 1
    })
```

Also, i have a question, what's purpose for `slice(1)`? I found that apple returns correct array with reviews, or is there something tricky?