### PR TITLE
restore code from previous list implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Example:
 var store = require('app-store-scraper');
 
 store.list({
-  collection: store.collection.TOP_FREE_IOS
+  collection: store.collection.TOP_FREE_IPAD,
+  category: store.category.GAMES_ACTION,
   num: 2
 })
 .then(console.log)
@@ -108,25 +109,35 @@ Returns:
 
 ```js
 [ { id: '1091944550',
+    appId: 'com.hypah.io.slither',
     title: 'slither.io',
     icon: 'http://is4.mzstatic.com/image/thumb/Purple30/v4/68/d7/4d/68d74df4-f4e7-d4a4-a8ea-dbab686e5554/mzl.ujmngosn.png/100x100bb-85.png',
     url: 'https://itunes.apple.com/us/app/slither.io/id1091944550?mt=8&uo=2',
+    price: 0,
+    currency: 'USD',
+    free: true,
+    description: 'Play against other people online! ...',
     developer: 'Steve Howse',
     developerUrl: 'https://itunes.apple.com/us/developer/steve-howse/id867992583?mt=8&uo=2',
     developerId: '867992583',
-    genres: 'Games',
+    genre: 'Games',
     genreId: '6014',
-    released: '2016-03-25' },
+    released: '2016-03-25T10:01:46-07:00' },
   { id: '1046846443',
+    appId: 'com.ubisoft.hungrysharkworld',
     title: 'Hungry Shark World',
     icon: 'http://is5.mzstatic.com/image/thumb/Purple60/v4/08/1a/8d/081a8d06-b4d5-528b-fa8e-f53646b6f797/mzl.ehtjvlft.png/100x100bb-85.png',
     url: 'https://itunes.apple.com/us/app/hungry-shark-world/id1046846443?mt=8&uo=2',
+    price: 0,
+    currency: 'USD',
+    free: true,
+    description: 'The stunning sequel to Hungry ...',
     developer: 'Ubisoft',
     developerUrl: 'https://itunes.apple.com/us/developer/ubisoft/id317644720?mt=8&uo=2',
     developerId: '317644720',
-    genres: 'Games',
+    genre: 'Games',
     genreId: '6014',
-    released: '2016-05-04' } ]
+    released: '2016-05-04T09:43:06-07:00' } ]
 ```
 
 ### search

--- a/lib/list.js
+++ b/lib/list.js
@@ -5,23 +5,29 @@ const common = require('./common');
 const c = require('./constants');
 
 function cleanApp (app) {
-  // dev id missing in macos apps, parsing from url
-  const developerId = parseInt(app['im:artist'].attributes.href.split(/id/g).pop());
+  let developerUrl, developerId;
+  if (app['im:artist'].attributes) {
+    developerUrl = app['im:artist'].attributes.href;
+    developerId = app['im:artist'].attributes.href.split('/id')[1].split('?mt')[0];
+  }
 
+  const price = parseFloat(app['im:price'].attributes.amount);
   return {
     id: app.id.attributes['im:id'],
     appId: app.id.attributes['im:bundleId'],
-    description: app.summary.label, // only present in mac right now
     title: app['im:name'].label,
-    icon: app['im:image'][2].label,
-    url: app.id.label,
+    icon: app['im:image'][app['im:image'].length - 1].label,
+    url: app.link.attributes.href,
+    price,
+    currency: app['im:price'].attributes.currency,
+    free: price === 0,
+    description: app.summary ? app.summary.label : undefined,
     developer: app['im:artist'].label,
-    developerUrl: app['im:artist'].attributes.href,
-    genre: app.category.attributes.term,
+    developerUrl,
+    developerId,
+    genre: app.category.attributes.label,
     genreId: app.category.attributes['im:id'],
-    released: app['im:releaseDate'].attributes.label,
-    price: app['im:price'].attributes.amount,
-    developerId
+    released: app['im:releaseDate'].label
   };
 }
 
@@ -38,6 +44,10 @@ function processResults (opts) {
 }
 
 function validate (opts) {
+  if (opts.category && !R.contains(opts.category, R.values(c.category))) {
+    throw Error('Invalid category ' + opts.category);
+  }
+
   opts.collection = opts.collection || c.collection.TOP_FREE_IOS;
   if (!R.contains(opts.collection, R.values(c.collection))) {
     throw Error(`Invalid collection ${opts.collection}`);

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -1,28 +1,32 @@
 'use strict';
 
 const assert = require('chai').assert;
+const assertValidApp = require('./common').assertValidApp;
 const assertValidUrl = require('./common').assertValidUrl;
 const store = require('../index');
 
-function assertValidApp (app) {
-  // list now returns less fields than the other methods
-  assert.isString(app.title);
-  assertValidUrl(app.url);
-  assertValidUrl(app.icon);
-  return app;
-}
-
 describe('List method', () => {
-  it('should fetch a valid application list for the given collection', () => {
+  it('should fetch a valid application list for the given category and collection', () => {
     return store.list({
+      category: store.category.GAMES_ACTION,
       collection: store.collection.TOP_FREE_IOS
     })
     .then((apps) => apps.map(assertValidApp))
-    .then((apps) => apps.map((app) => assert.isNotEmpty(app.title)));
+    .then((apps) => apps.map((app) => assert(app.free)));
+  });
+
+  it('should validate the category', () => {
+    return store.list({
+      category: 'wrong',
+      collection: store.collection.TOP_FREE_IOS
+    })
+    .then(assert.fail)
+    .catch((e) => assert.equal(e.message, 'Invalid category wrong'));
   });
 
   it('should validate the collection', () => {
     return store.list({
+      category: store.category.GAMES_ACTION,
       collection: 'wrong'
     })
     .then(assert.fail)
@@ -31,6 +35,7 @@ describe('List method', () => {
 
   it('should validate the results number', () => {
     return store.list({
+      category: store.category.GAMES_ACTION,
       collection: store.collection.TOP_FREE_IOS,
       num: 250
     })


### PR DESCRIPTION
Now that we switched to a list url that uses the previous format for the list response, we can put back some of the code that we removed when we made switch. I basically when through git history and restored what seemed relevant.

@koltclassic mind taking a look at this?