### PR TITLE
check for case where single review object is returned

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -5,16 +5,16 @@ const common = require('./common');
 const app = require('./app');
 const c = require('./constants');
 
-function ensureArray(value) {
+function ensureArray (value) {
   if (!value) {
     return [];
   }
 
-  if (typeof value === 'object') {
-    return [value];
+  if (Array.isArray(value)) {
+    return value;
   }
 
-  return value;
+  return [value];
 }
 
 function cleanList (results) {

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -5,8 +5,20 @@ const common = require('./common');
 const app = require('./app');
 const c = require('./constants');
 
+function ensureArray(value) {
+  if (!value) {
+    return [];
+  }
+
+  if (typeof value === 'object') {
+    return [value];
+  }
+
+  return value;
+}
+
 function cleanList (results) {
-  const reviews = results.feed.entry || [];
+  const reviews = ensureArray(results.feed.entry);
   return reviews.map((review) => ({
     id: review.id.label,
     userName: review.author.name.label,


### PR DESCRIPTION
I ran into a case where one review was being returned for an app and I think the xml2js ends up returning a single object for `results.feed.entry` vs an array. This adds a check for it.

I'd add a test for this but it looks like these tests are hitting live apps vs mocked responses using `sinon` or `nock`. That seems brittle as the responses could change over time. I'd be happy to switch the tests over to using mocked responses if that's ok with the module owner.

Re-opening to trigger a new test.