### PR TITLE
Add `ratings` option to `.app` to load ratings and histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,15 @@ Results:
   supportedDevices:
    [ 'iPhone-3GS',
      'iPadWifi',
-     ... ] }
+     ... ],
+  ratings: 652230,
+  histogram: {
+    '1': 7004,
+    '2': 6650,
+    '3': 26848,
+    '4': 140625,
+    '5': 471103
+  }}
 ```
 
 ### list

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Retrieves the full detail of an application. Options:
 * `id`: the iTunes "trackId" of the app, for example `553834731` for Candy Crush Saga. Either this or the `appId` should be provided.
 * `appId`: the iTunes "bundleId" of the app, for example `com.midasplayer.apps.candycrushsaga` for Candy Crush Saga. Either this or the `id` should be provided.
 * `country`: the two letter country code to get the app details from. Defaults to `us`. Note this also affects the language of the data.
++ `ratings`: load additional ratings information like `ratings` number and `histogram`
 
 Example:
 
@@ -75,7 +76,22 @@ Results:
   supportedDevices:
    [ 'iPhone-3GS',
      'iPadWifi',
-     ... ],
+     ... ]}
+```
+
+Example with `ratings` option:
+
+```javascript
+var store = require('app-store-scraper');
+
+store.app({id: 553834731, ratings: true}).then(console.log).catch(console.log);
+```
+
+Results:
+
+```javascript
+{ id: 553834731,
+  appId: 'com.midasplayer.apps.candycrushsaga',
   ratings: 652230,
   histogram: {
     '1': 7004,
@@ -83,7 +99,8 @@ Results:
     '3': 26848,
     '4': 140625,
     '5': 471103
-  }}
+  }
+}
 ```
 
 ### list

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Available methods:
 - [suggest](#suggest): Given a string returns up to 50 suggestions to complete a search query term.
 - [similar](#similar): Returns the list of "customers also bought" apps shown in the app's detail page.
 - [reviews](#reviews): Retrieves a page of reviews for the app.
+- [ratings](#ratings): Retrieves the ratings for the app.
 
 ### app
 Retrieves the full detail of an application. Options:
@@ -353,6 +354,41 @@ Returns:
     url: 'https://itunes.apple.com/us/review?id=553834731&type=Purple%20Software' },
   (...)
 ]
+```
+
+### ratings
+
+Retrieves the ratings for the app. Options:
+
+* `id`: the iTunes "trackId" of the app, for example `553834731` for Candy Crush Saga. Either this or the `appId` should be provided.
+* `appId`: the iTunes "bundleId" of the app, for example `com.midasplayer.apps.candycrushsaga` for Candy Crush Saga. Either this or the `id` should be provided.
+* `country`: the two letter country code to get the reviews from. Defaults to `us`.
+
+Example:
+
+```js
+var store = require('app-store-scraper');
+
+store.ratings({
+  appId: 'com.midasplayer.apps.candycrushsaga',
+})
+.then(console.log)
+.catch(console.log);
+```
+
+Returns:
+
+```js
+{
+  ratings: 652719,
+  histogram: {
+    '1': 7012,
+    '2': 6655,
+    '3': 26876,
+    '4': 140680,
+    '5': 471496
+  }
+}
 ```
 
 ### Memoization

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Results:
 ```javascript
 { id: 553834731,
   appId: 'com.midasplayer.apps.candycrushsaga',
+
+  // ... like above
+
   ratings: 652230,
   histogram: {
     '1': 7004,

--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ const methods = {
   developer: require('./lib/developer'),
   suggest: require('./lib/suggest'),
   similar: require('./lib/similar'),
-  reviews: require('./lib/reviews'),
-  ratings: require('./lib/ratings')
+  reviews: require('./lib/reviews')
 };
 
 function memoized (opts) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const methods = {
   developer: require('./lib/developer'),
   suggest: require('./lib/suggest'),
   similar: require('./lib/similar'),
-  reviews: require('./lib/reviews')
+  reviews: require('./lib/reviews'),
+  ratings: require('./lib/ratings')
 };
 
 function memoized (opts) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -17,15 +17,17 @@ function app (opts) {
       throw Error('App not found (404)');
     }
 
-    return results[0];
-  })
-  .then((result) => {
-    if (!opts.id) { opts.id = result.id; }
+    const result = results[0];
 
-    return Promise.all([result, ratings(opts)]);
-  })
-  .then(([appResult, ratingsResult]) => {
-    return Object.assign({}, appResult, ratingsResult);
+    if (opts.ratings) {
+      if (!opts.id) { opts.id = result.id; }
+      return Promise.all([result, ratings(opts)])
+      .then(([appResult, ratingsResult]) => {
+        return Object.assign({}, appResult, ratingsResult);
+      })
+    }
+
+    return result
   })
 }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('./common');
+const ratings = require('./ratings');
 
 function app (opts) {
   return new Promise(function (resolve) {
@@ -17,7 +18,15 @@ function app (opts) {
     }
 
     return results[0];
-  });
+  })
+  .then((result) => {
+    if (!opts.id) { opts.id = result.id; }
+
+    return Promise.all([result, ratings(opts)]);
+  })
+  .then(([appResult, ratingsResult]) => {
+    return Object.assign({}, appResult, ratingsResult);
+  })
 }
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -21,10 +21,7 @@ function app (opts) {
 
     if (opts.ratings) {
       if (!opts.id) { opts.id = result.id; }
-      return Promise.all([result, ratings(opts)])
-      .then(([appResult, ratingsResult]) => {
-        return Object.assign({}, appResult, ratingsResult);
-      })
+      return ratings(opts).then((ratingsResult) => Object.assign({}, result, ratingsResult));
     }
 
     return result

--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('./common');
+const cheerio = require('cheerio');
+
+function ratings (opts) {
+  return new Promise(function (resolve) {
+    if (!opts.id) {
+      throw Error('id is required');
+    }
+
+    const country = opts.country || 'us';
+    const storeFront = common.storeId(opts.country);
+    const idValue = opts.id;
+    const url = `https://itunes.apple.com/${country}/customer-reviews/id${idValue}?displayable-kind=11`;
+
+    resolve(common.request(url, {
+      'X-Apple-Store-Front': `${storeFront},12`
+    }));
+  })
+  .then((html) => {
+    if (html.length === 0) {
+      throw Error('App not found (404)');
+    }
+
+    return parseRatings(html);
+  });
+}
+
+module.exports = ratings;
+
+function parseRatings (html) {
+  const $ = cheerio.load(html);
+
+  const ratingsMatch = $('.rating-count').text().match(/\d+/);
+  const ratings = Array.isArray(ratingsMatch) ? parseInt(ratingsMatch[0]) : 0;
+
+  const ratingsByStar = $('.vote .total').map((i, el) => parseInt($(el).text())).get();
+
+  const histogram = ratingsByStar.reduce((acc, ratingsForStar, index) => {
+    return Object.assign(acc, { [5-index]: ratingsForStar });
+  }, {});
+
+  return { ratings, histogram };
+}

--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -6,19 +6,6 @@ const app = require('./app');
 
 function ratings (opts) {
   return new Promise(function (resolve, reject) {
-    if (opts.id) {
-      resolve(opts.id);
-    } else if (opts.appId) {
-      app(opts).then((app) => resolve(app.id)).catch(reject);
-    } else {
-      throw Error('Either id or appId is required');
-    }
-  })
-  .then((id) => {
-    opts.id = id;
-    return opts;
-  })
-  .then((opts) => {
     if (!opts.id) {
       throw Error('id is required');
     }
@@ -28,9 +15,9 @@ function ratings (opts) {
     const idValue = opts.id;
     const url = `https://itunes.apple.com/${country}/customer-reviews/id${idValue}?displayable-kind=11`;
 
-    return common.request(url, {
+    resolve(common.request(url, {
       'X-Apple-Store-Front': `${storeFront},12`
-    });
+    }));
   })
   .then((html) => {
     if (html.length === 0) {

--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -1,10 +1,24 @@
 'use strict';
 
-const common = require('./common');
 const cheerio = require('cheerio');
+const common = require('./common');
+const app = require('./app');
 
 function ratings (opts) {
-  return new Promise(function (resolve) {
+  return new Promise(function (resolve, reject) {
+    if (opts.id) {
+      resolve(opts.id);
+    } else if (opts.appId) {
+      app(opts).then((app) => resolve(app.id)).catch(reject);
+    } else {
+      throw Error('Either id or appId is required');
+    }
+  })
+  .then((id) => {
+    opts.id = id;
+    return opts;
+  })
+  .then((opts) => {
     if (!opts.id) {
       throw Error('id is required');
     }
@@ -14,9 +28,9 @@ function ratings (opts) {
     const idValue = opts.id;
     const url = `https://itunes.apple.com/${country}/customer-reviews/id${idValue}?displayable-kind=11`;
 
-    resolve(common.request(url, {
+    return common.request(url, {
       'X-Apple-Store-Front': `${storeFront},12`
-    }));
+    });
   })
   .then((html) => {
     if (html.length === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "11.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.2.tgz",
+      "integrity": "sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg=="
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -138,6 +143,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -200,6 +210,19 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.1",
+        "entities": "1.1.2",
+        "htmlparser2": "3.10.1",
+        "lodash": "4.17.5",
+        "parse5": "3.0.3"
+      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -268,6 +291,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.3",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.2"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
     "d": {
       "version": "0.1.1",
@@ -344,6 +383,37 @@
         "isarray": "1.0.0"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "1.3.1",
+        "entities": "1.1.2"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1.3.1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0.1.1",
+        "domelementtype": "1.3.1"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -352,6 +422,11 @@
       "requires": {
         "jsbn": "0.1.1"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "es5-ext": {
       "version": "0.10.38",
@@ -828,6 +903,39 @@
         "ansi-regex": "2.1.1"
       }
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "1.3.1",
+        "domhandler": "2.4.2",
+        "domutils": "1.5.1",
+        "entities": "1.1.2",
+        "inherits": "2.0.3",
+        "readable-stream": "3.3.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "2.0.3",
+            "string_decoder": "1.2.0",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -863,8 +971,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -1060,8 +1167,7 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -1211,6 +1317,14 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
       "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
     },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "1.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -1262,6 +1376,14 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "11.12.2"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1685,8 +1807,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/facundoolano/app-store-scraper#readme",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
     "debug": "^2.2.0",
     "memoizee": "^0.3.10",
     "ramda": "^0.21.0",

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -17,6 +17,14 @@ describe('App method', () => {
         assert(app.score > 0);
         assert(app.score <= 5);
 
+        assert.isNumber(app.ratings);
+        assert.isObject(app.histogram);
+        assert.isNumber(app.histogram['1']);
+        assert.isNumber(app.histogram['2']);
+        assert.isNumber(app.histogram['3']);
+        assert.isNumber(app.histogram['4']);
+        assert.isNumber(app.histogram['5']);
+
         assert.isNumber(app.reviews);
 
         assert.isString(app.description);
@@ -57,6 +65,8 @@ describe('App method', () => {
         assert.equal(app.id, '553834731');
         assert.equal(app.title, 'Candy Crush Saga');
         assert.equal(app.url, 'https://itunes.apple.com/us/app/candy-crush-saga/id553834731?mt=8&uo=4');
+        assert.isNumber(app.ratings);
+        assert.isObject(app.histogram);
       });
   });
 

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -73,6 +73,11 @@ describe('App method', () => {
         .then((app) => {
           assert.isNumber(app.ratings);
           assert.isObject(app.histogram);
+          assert.isNumber(app.histogram['1']);
+          assert.isNumber(app.histogram['2']);
+          assert.isNumber(app.histogram['3']);
+          assert.isNumber(app.histogram['4']);
+          assert.isNumber(app.histogram['5']);
         });
     });
   });

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -17,13 +17,8 @@ describe('App method', () => {
         assert(app.score > 0);
         assert(app.score <= 5);
 
-        assert.isNumber(app.ratings);
-        assert.isObject(app.histogram);
-        assert.isNumber(app.histogram['1']);
-        assert.isNumber(app.histogram['2']);
-        assert.isNumber(app.histogram['3']);
-        assert.isNumber(app.histogram['4']);
-        assert.isNumber(app.histogram['5']);
+        assert.isNotOk(app.ratings);
+        assert.isNotOk(app.histogram);
 
         assert.isNumber(app.reviews);
 
@@ -59,14 +54,40 @@ describe('App method', () => {
       });
   });
 
+  describe('with ratings option enabled', () => {
+    it('should fetch valid application data', () => {
+      return store.app({id: '553834731', ratings: true})
+        .then((app) => {
+          assert.isNumber(app.ratings);
+          assert.isObject(app.histogram);
+          assert.isNumber(app.histogram['1']);
+          assert.isNumber(app.histogram['2']);
+          assert.isNumber(app.histogram['3']);
+          assert.isNumber(app.histogram['4']);
+          assert.isNumber(app.histogram['5']);
+        });
+    });
+
+
+    it('should fetch app with bundle id', () => {
+      return store.app({appId: 'com.midasplayer.apps.candycrushsaga', ratings: true})
+        .then((app) => {
+          assert.isNumber(app.ratings);
+          assert.isObject(app.histogram);
+        });
+    });
+
+  })
+
+
   it('should fetch app with bundle id', () => {
     return store.app({appId: 'com.midasplayer.apps.candycrushsaga'})
       .then((app) => {
         assert.equal(app.id, '553834731');
         assert.equal(app.title, 'Candy Crush Saga');
         assert.equal(app.url, 'https://itunes.apple.com/us/app/candy-crush-saga/id553834731?mt=8&uo=4');
-        assert.isNumber(app.ratings);
-        assert.isObject(app.histogram);
+        assert.isNotOk(app.ratings);
+        assert.isNotOk(app.histogram);
       });
   });
 

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -68,7 +68,6 @@ describe('App method', () => {
         });
     });
 
-
     it('should fetch app with bundle id', () => {
       return store.app({appId: 'com.midasplayer.apps.candycrushsaga', ratings: true})
         .then((app) => {
@@ -76,9 +75,7 @@ describe('App method', () => {
           assert.isObject(app.histogram);
         });
     });
-
-  })
-
+  });
 
   it('should fetch app with bundle id', () => {
     return store.app({appId: 'com.midasplayer.apps.candycrushsaga'})

--- a/test/lib.ratings.js
+++ b/test/lib.ratings.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('chai').assert;
+const store = require('../index');
+
+describe('Ratings method', () => {
+  it('should fetch valid ratings data', () => {
+    return store.ratings({id: '553834731'})
+      .then((ratings) => {
+        assert.isObject(ratings)
+        assert.isNumber(ratings.ratings)
+        assert.isObject(ratings.histogram)
+        assert.isNumber(ratings.histogram['1'])
+        assert.isNumber(ratings.histogram['2'])
+        assert.isNumber(ratings.histogram['3'])
+        assert.isNumber(ratings.histogram['4'])
+        assert.isNumber(ratings.histogram['5'])
+      });
+  });
+});

--- a/test/lib.ratings.js
+++ b/test/lib.ratings.js
@@ -3,9 +3,11 @@
 const assert = require('chai').assert;
 const store = require('../index');
 
+const id = '553834731'
+
 describe('Ratings method', () => {
-  it('should fetch valid ratings data', () => {
-    return store.ratings({id: '553834731'})
+  it('should fetch valid ratings data by id', () => {
+    return store.ratings({id})
       .then((ratings) => {
         assert.isObject(ratings)
         assert.isNumber(ratings.ratings)
@@ -15,6 +17,17 @@ describe('Ratings method', () => {
         assert.isNumber(ratings.histogram['3'])
         assert.isNumber(ratings.histogram['4'])
         assert.isNumber(ratings.histogram['5'])
+      });
+  });
+
+  it('should fetch valid ratings data by id and country', () => {
+    let ratingsForUs, ratingsForFr
+    return store.ratings({id})
+      .then((ratings) => {ratingsForUs = ratings})
+      .then(() => store.ratings({id, country: 'fr'}))
+      .then((ratings) => {ratingsForFr = ratings})
+      .then(() => {
+        assert.notDeepEqual(ratingsForUs, ratingsForFr)
       });
   });
 });

--- a/test/lib.ratings.js
+++ b/test/lib.ratings.js
@@ -21,20 +21,6 @@ describe('Ratings method', () => {
       });
   });
 
-  it('should fetch valid ratings data by appId', () => {
-    return store.ratings({appId})
-      .then((ratings) => {
-        assert.isObject(ratings);
-        assert.isNumber(ratings.ratings);
-        assert.isObject(ratings.histogram);
-        assert.isNumber(ratings.histogram['1']);
-        assert.isNumber(ratings.histogram['2']);
-        assert.isNumber(ratings.histogram['3']);
-        assert.isNumber(ratings.histogram['4']);
-        assert.isNumber(ratings.histogram['5']);
-      });
-  });
-
   it('should fetch valid ratings data by id and country', () => {
     let ratingsForUs, ratingsForFr;
     return store.ratings({id})

--- a/test/lib.ratings.js
+++ b/test/lib.ratings.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const assert = require('chai').assert;
-const store = require('../index');
+const ratings = require('../lib/ratings');
 
 const id = '553834731';
 const appId = 'com.midasplayer.apps.candycrushsaga';
 
 describe('Ratings method', () => {
   it('should fetch valid ratings data by id', () => {
-    return store.ratings({id})
+    return ratings({id})
       .then((ratings) => {
         assert.isObject(ratings);
         assert.isNumber(ratings.ratings);
@@ -23,9 +23,9 @@ describe('Ratings method', () => {
 
   it('should fetch valid ratings data by id and country', () => {
     let ratingsForUs, ratingsForFr;
-    return store.ratings({id})
+    return ratings({id})
       .then((ratings) => {ratingsForUs = ratings;})
-      .then(() => store.ratings({id, country: 'fr'}))
+      .then(() => ratings({id, country: 'fr'}))
       .then((ratings) => {ratingsForFr = ratings;})
       .then(() => {
         assert.notDeepEqual(ratingsForUs, ratingsForFr);

--- a/test/lib.ratings.js
+++ b/test/lib.ratings.js
@@ -3,31 +3,46 @@
 const assert = require('chai').assert;
 const store = require('../index');
 
-const id = '553834731'
+const id = '553834731';
+const appId = 'com.midasplayer.apps.candycrushsaga';
 
 describe('Ratings method', () => {
   it('should fetch valid ratings data by id', () => {
     return store.ratings({id})
       .then((ratings) => {
-        assert.isObject(ratings)
-        assert.isNumber(ratings.ratings)
-        assert.isObject(ratings.histogram)
-        assert.isNumber(ratings.histogram['1'])
-        assert.isNumber(ratings.histogram['2'])
-        assert.isNumber(ratings.histogram['3'])
-        assert.isNumber(ratings.histogram['4'])
-        assert.isNumber(ratings.histogram['5'])
+        assert.isObject(ratings);
+        assert.isNumber(ratings.ratings);
+        assert.isObject(ratings.histogram);
+        assert.isNumber(ratings.histogram['1']);
+        assert.isNumber(ratings.histogram['2']);
+        assert.isNumber(ratings.histogram['3']);
+        assert.isNumber(ratings.histogram['4']);
+        assert.isNumber(ratings.histogram['5']);
+      });
+  });
+
+  it('should fetch valid ratings data by appId', () => {
+    return store.ratings({appId})
+      .then((ratings) => {
+        assert.isObject(ratings);
+        assert.isNumber(ratings.ratings);
+        assert.isObject(ratings.histogram);
+        assert.isNumber(ratings.histogram['1']);
+        assert.isNumber(ratings.histogram['2']);
+        assert.isNumber(ratings.histogram['3']);
+        assert.isNumber(ratings.histogram['4']);
+        assert.isNumber(ratings.histogram['5']);
       });
   });
 
   it('should fetch valid ratings data by id and country', () => {
-    let ratingsForUs, ratingsForFr
+    let ratingsForUs, ratingsForFr;
     return store.ratings({id})
-      .then((ratings) => {ratingsForUs = ratings})
+      .then((ratings) => {ratingsForUs = ratings;})
       .then(() => store.ratings({id, country: 'fr'}))
-      .then((ratings) => {ratingsForFr = ratings})
+      .then((ratings) => {ratingsForFr = ratings;})
       .then(() => {
-        assert.notDeepEqual(ratingsForUs, ratingsForFr)
+        assert.notDeepEqual(ratingsForUs, ratingsForFr);
       });
   });
 });

--- a/test/lib.ratings.js
+++ b/test/lib.ratings.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const assert = require('chai').assert;
-const ratings = require('../lib/ratings');
+const store = require('../index');
 
 const id = '553834731';
 const appId = 'com.midasplayer.apps.candycrushsaga';
 
 describe('Ratings method', () => {
   it('should fetch valid ratings data by id', () => {
-    return ratings({id})
+    return store.ratings({id})
       .then((ratings) => {
         assert.isObject(ratings);
         assert.isNumber(ratings.ratings);
@@ -23,11 +23,12 @@ describe('Ratings method', () => {
 
   it('should fetch valid ratings data by id and country', () => {
     let ratingsForUs, ratingsForFr;
-    return ratings({id})
+    return store.ratings({id})
       .then((ratings) => {ratingsForUs = ratings;})
-      .then(() => ratings({id, country: 'fr'}))
+      .then(() => store.ratings({id, country: 'fr'}))
       .then((ratings) => {ratingsForFr = ratings;})
       .then(() => {
+        console.log('ratingsForUs', ratingsForUs)
         assert.notDeepEqual(ratingsForUs, ratingsForFr);
       });
   });


### PR DESCRIPTION
This PR add the functionality discussed in #35 and it adds the following:

- `.app` now accepts an optional parameter `ratings: true`
- when this option is present, the fields `ratings` and `histogram` are added to the result of `.app`

here the tests that describe the functionality (see https://github.com/christian-fei/app-store-scraper/blob/master/test/lib.app.js#L57):

```
  describe('with ratings option enabled', () => {
    it('should fetch valid application data', () => {
      return store.app({id: '553834731', ratings: true})
        .then((app) => {
          assert.isNumber(app.ratings);
          assert.isObject(app.histogram);
          assert.isNumber(app.histogram['1']);
          assert.isNumber(app.histogram['2']);
          assert.isNumber(app.histogram['3']);
          assert.isNumber(app.histogram['4']);
          assert.isNumber(app.histogram['5']);
        });
    });

    it('should fetch app with bundle id', () => {
      return store.app({appId: 'com.midasplayer.apps.candycrushsaga', ratings: true})
        .then((app) => {
          assert.isNumber(app.ratings);
          assert.isObject(app.histogram);
        });
    });
  });
```


Cheers


(note that the build fails due to an already broken test, namely `Suggest method should return five suggestion for a common term`)