### PR TITLE
remove podcasts from result

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -70,7 +70,10 @@ function lookup (ids, idField, country, requestOptions) {
   const url = `${LOOKUP_URL}?${idField}=${joinedIds}&country=${country}&entity=software`;
   return doRequest(url, {}, requestOptions)
     .then(JSON.parse)
-    .then((res) => res.results.map(cleanApp));
+    .then((res) => res.results.filter(function (app) {
+      return typeof app.wrapperType === 'undefined' || app.wrapperType === 'software';
+    }))
+    .then((res) => res.map(cleanApp));
 }
 
 function storeId (countryCode) {


### PR DESCRIPTION
There is now some strange things about handling podcasts, albums, artists, etc...

For example, 

http://itunes.apple.com/album/id1465280815
https://podcasts.apple.com/ru/podcast/bulletproof-radio/id451295014

If you'll try to fetch information about podcast as for an app (using app method) you'll get unpredictable result from function clearApp.

So the solution is to use field "wrapperType" and clean out everything that is not a software.

There is also check on undefined, for the case if this field will dissapear from result.

Tests are broken, I fix some of them in https://github.com/facundoolano/app-store-scraper/pull/102.