### PR TITLE
Correctly pass app list link

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -17,12 +17,13 @@ function cleanApp (app) {
   }
 
   const price = parseFloat(app['im:price'].attributes.amount);
+  const link = app.link.find(link => link.attributes.rel === 'alternate');
   return {
     id: app.id.attributes['im:id'],
     appId: app.id.attributes['im:bundleId'],
     title: app['im:name'].label,
     icon: app['im:image'][app['im:image'].length - 1].label,
-    url: app.link.attributes.href,
+    url: link && link.attributes.href,
     price,
     currency: app['im:price'].attributes.currency,
     free: price === 0,


### PR DESCRIPTION
Seems like app.link is an array nowadays, so we need to search
for alternate link.