### PR TITLE
isMac flag for apps

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -38,7 +38,8 @@ function cleanApp (app) {
     screenshots: app.screenshotUrls,
     ipadScreenshots: app.ipadScreenshotUrls,
     appletvScreenshots: app.appletvScreenshotUrls,
-    supportedDevices: app.supportedDevices
+    supportedDevices: app.supportedDevices,
+    isMac: typeof app.supportedDevices === "undefined"
   };
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -39,7 +39,7 @@ function cleanApp (app) {
     ipadScreenshots: app.ipadScreenshotUrls,
     appletvScreenshots: app.appletvScreenshotUrls,
     supportedDevices: app.supportedDevices,
-    isMac: typeof app.supportedDevices === "undefined"
+    isMac: app.kind === "mac-software"
   };
 }
 


### PR DESCRIPTION
Currently it's not clear if an app is from the iOS or macOS App Store. I added such a flag to response.