### PR TITLE
Multiple format options for reviews, allows review date fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,9 @@ Retrieves a page of reviews for the app. Options:
 * `country`: the two letter country code to get the reviews from. Defaults to `us`.
 * `page`: the review page number to retrieve. Defaults to `1`, maximum allowed is `10`.
 * `sort`: the review sort order. Defaults to `store.sort.RECENT`, available options are `store.sort.RECENT` and `store.sort.HELPFUL`.
+* `format`: the format used to retrieve data. Defaults to `store.format.JSON`, available options are `store.format.JSON` and `store.sort.XML`.
+
+*Note: using `format: store.format.XML` has the added vantage of returning the review date*
 
 Example:
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -100,6 +100,11 @@ const sort = {
   HELPFUL: 'mostHelpful'
 };
 
+const format = {
+  JSON: 'json',
+  XML: 'xml'
+};
+
 // From https://github.com/gonzoua/random-stuff/blob/master/appstorereviews.rb
 const markets = {
   DZ: 143563,
@@ -218,4 +223,4 @@ const markets = {
   YE: 143571
 };
 
-module.exports = {collection, category, device, sort, markets};
+module.exports = {collection, category, device, sort, markets, format};

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -4,6 +4,7 @@ const R = require('ramda');
 const common = require('./common');
 const app = require('./app');
 const c = require('./constants');
+const xml2js = require('xml2js').parseString;
 
 function ensureArray (value) {
   if (!value) {
@@ -17,7 +18,19 @@ function ensureArray (value) {
   return [value];
 }
 
-function cleanList (results) {
+function parseXml (body) {
+  return new Promise((resolve, reject) => {
+    xml2js(body, {
+      trim: true,
+      explicitArray: false
+    }, (err, result) => {
+      if (err)reject(err);
+      else resolve(result);
+    });
+  });
+}
+
+function cleanJsonList (results) {
   const reviews = ensureArray(results.feed.entry);
   return reviews.map((review) => ({
     id: review.id.label,
@@ -31,8 +44,39 @@ function cleanList (results) {
   }));
 }
 
+function cleanXmlList (results) {
+  const reviews = ensureArray(results.feed.entry);
+  return reviews.map((review) => ({
+    id: review.id,
+    date: review.updated,
+    userName: review.author.name,
+    userUrl: review.author.uri,
+    version: review['im:version'],
+    score: parseInt(review['im:rating']),
+    title: review.title,
+    text: R.find(val => val['$'].type === 'text')(review.content)._,
+    url: review.link['$'].href
+  }));
+}
+
+const handlers = {
+  [c.format.JSON]: {
+    parse: JSON.parse,
+    cleanList: cleanJsonList
+  },
+  [c.format.XML]: {
+    parse: parseXml,
+    cleanList: cleanXmlList
+  }
+};
+
 const reviews = (opts) => new Promise((resolve) => {
   validate(opts);
+  opts = opts || {};
+  opts.sort = opts.sort || c.sort.RECENT;
+  opts.page = opts.page || 1;
+  opts.country = opts.country || 'us';
+  opts.format = opts.format || c.format.JSON;
 
   if (opts.id) {
     resolve(opts.id);
@@ -41,16 +85,11 @@ const reviews = (opts) => new Promise((resolve) => {
   }
 })
   .then((id) => {
-    opts = opts || {};
-    opts.sort = opts.sort || c.sort.RECENT;
-    opts.page = opts.page || 1;
-    opts.country = opts.country || 'us';
-
-    const url = `https://itunes.apple.com/${opts.country}/rss/customerreviews/page=${opts.page}/id=${id}/sortby=${opts.sort}/json`;
+    const url = `https://itunes.apple.com/${opts.country}/rss/customerreviews/page=${opts.page}/id=${id}/sortby=${opts.sort}/${opts.format}`;
     return common.request(url, {}, opts.requestOptions);
   })
-  .then(JSON.parse)
-  .then(cleanList);
+  .then(handlers[opts.format].parse)
+  .then(handlers[opts.format].cleanList);
 
 function validate (opts) {
   if (!opts.id && !opts.appId) {
@@ -67,6 +106,10 @@ function validate (opts) {
 
   if (opts.page && opts.page > 10) {
     throw new Error('Page cannot be greater than 10');
+  }
+
+  if (opts.format && !R.contains(opts.format, R.values(c.format))) {
+    throw new Error('Invalid format ' + opts.format);
   }
 }
 

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -3,6 +3,7 @@
 const store = require('../index');
 const assert = require('chai').assert;
 const assertValidUrl = require('./common').assertValidUrl;
+const R = require('ramda')
 
 function assertValid (review) {
   assert.isString(review.id);
@@ -57,4 +58,39 @@ describe('Reviews method', () => {
       })
       .catch(done);
   });
+
+  const TESTS_MAP=[
+    {
+      description:'should retrive the same reviews regarless of the format - candycrush',
+      input:{ appId: 'com.midasplayer.apps.candycrushsaga'}
+    },
+    {
+      description:'should retrive the same reviews regarless of the format - facebook',
+            input:{ id: '284882215', page:2}
+    },
+    {
+      description:'should retrive the same reviews regarless of the format - snapchat',
+            input:{ id: '447188370',sort:store.sort.HELPFUL}
+    },
+    {
+      description:'should retrive the same reviews regarless of the format - google',
+            input:{ appId: 'com.google.googlemobile',country:'it'}
+    }
+  ]
+
+  TESTS_MAP.map(({description,input})=>{
+  it.only(description,async ()=>{
+    const xmlReview = await store.reviews({
+      ...input,
+      format: store.format.XML
+    })
+
+    const jsonReview = await store.reviews({
+      ...input,
+      format: store.format.JSON
+    })
+
+      assert.deepEqual(jsonReview, xmlReview.map(R.omit(['date'])))
+  })
+  })
 });

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -3,7 +3,7 @@
 const store = require('../index');
 const assert = require('chai').assert;
 const assertValidUrl = require('./common').assertValidUrl;
-const R = require('ramda')
+const R = require('ramda');
 
 function assertValid (review) {
   assert.isString(review.id);
@@ -59,38 +59,41 @@ describe('Reviews method', () => {
       .catch(done);
   });
 
-  const TESTS_MAP=[
+  const TESTS_MAP = [
     {
-      description:'should retrive the same reviews regarless of the format - candycrush',
-      input:{ appId: 'com.midasplayer.apps.candycrushsaga'}
+      description: 'should retrive the same reviews regarless of the format - candycrush',
+      input: { appId: 'com.midasplayer.apps.candycrushsaga' }
     },
     {
-      description:'should retrive the same reviews regarless of the format - facebook',
-            input:{ id: '284882215', page:2}
+      description: 'should retrive the same reviews regarless of the format - facebook',
+      input: { id: '284882215', page: 2 }
     },
     {
-      description:'should retrive the same reviews regarless of the format - snapchat',
-            input:{ id: '447188370',sort:store.sort.HELPFUL}
+      description: 'should retrive the same reviews regarless of the format - snapchat',
+      input: { id: '447188370', sort: store.sort.HELPFUL }
     },
     {
-      description:'should retrive the same reviews regarless of the format - google',
-            input:{ appId: 'com.google.googlemobile',country:'it'}
+      description: 'should retrive the same reviews regarless of the format - google',
+      input: { appId: 'com.google.googlemobile', country: 'it' }
     }
-  ]
+  ];
 
-  TESTS_MAP.map(({description,input})=>{
-  it.only(description,async ()=>{
-    const xmlReview = await store.reviews({
-      ...input,
-      format: store.format.XML
-    })
-
-    const jsonReview = await store.reviews({
-      ...input,
-      format: store.format.JSON
-    })
-
-      assert.deepEqual(jsonReview, xmlReview.map(R.omit(['date'])))
-  })
-  })
+  TESTS_MAP.map(({description, input}) => {
+    it(description, function () {
+      return Promise.all([
+        store.reviews({
+          ...input,
+          format: store.format.XML
+        }),
+        store.reviews({
+          ...input,
+          format: store.format.JSON
+        })
+      ])
+        .then((results) => {
+          const [xmlReview, jsonReview] = results;
+          assert.deepEqual(jsonReview, xmlReview.map(R.omit(['date'])));
+        });
+    });
+  });
 });


### PR DESCRIPTION
I've noticed that there's another PR that introduces the date field in the review methods by moving 
`store.reviews` to XML.

Parsing XML is slower but gives access to the date field so I think the user should have the ability to chose their preferred format based on requirements. 

This MR introduces the ability to use the XML RSS feed while fetching review data. 
I've added some tests for making sure that popular app returns the same reviews independently from the chosen format or parameters.