### PR TITLE
Add connOptions to be able to set number of attempts to download data

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -10,7 +10,7 @@ function app (opts) {
     }
     const idField = opts.id ? 'id' : 'bundleId';
     const idValue = opts.id || opts.appId;
-    resolve(common.lookup([idValue], idField, opts.country, opts.requestOptions));
+    resolve(common.lookup([idValue], idField, opts.country, opts.requestOptions, common.prepareConnOptions(opts)));
   })
     .then((results) => {
       if (results.length === 0) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -91,7 +91,7 @@ function storeId (countryCode) {
 
 function prepareConnOptions (opts) {
   return {
-    maxAttempts: opts.maxAttempts
+    maxAttempts: opts.maxAttempts || 1,
   }
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -58,7 +58,12 @@ const doRequest = (url, headers, requestOptions, connOptions) => new Promise(fun
         debug('There was a problem but do an another attempt to download data');
         const newConnOptions = Object.assign({}, connOptions);
         newConnOptions.maxAttempts -= 1;
-        return doRequest(url, headers, requestOptions, newConnOptions);
+        resolve(
+          new Promise(resolve => setTimeout(resolve, 1000 * newConnOptions.attemptWait))
+          .then(() => {
+            return doRequest(url, headers, requestOptions, newConnOptions);
+          })
+        );
       } else {
         return reject({ response });
       }
@@ -92,6 +97,7 @@ function storeId (countryCode) {
 function prepareConnOptions (opts) {
   return {
     maxAttempts: opts.maxAttempts || 1,
+    attemptWait: (typeof opts.attemptWait === 'undefined') ? 1 : opts.attemptWait,
   }
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -43,7 +43,7 @@ function cleanApp (app) {
 }
 
 // TODO add an optional parse function
-const doRequest = (url, headers, requestOptions) => new Promise(function (resolve, reject) {
+const doRequest = (url, headers, requestOptions, connOptions) => new Promise(function (resolve, reject) {
   debug('Making request: %s %j %o', url, headers, requestOptions);
 
   requestOptions = Object.assign({ method: 'GET' }, requestOptions);
@@ -54,7 +54,14 @@ const doRequest = (url, headers, requestOptions) => new Promise(function (resolv
       return reject(error);
     }
     if (response.statusCode >= 400) {
-      return reject({ response });
+      if ((connOptions.maxAttempts || 1) > 1) {
+        debug('There was a problem but do an another attempt to download data');
+        const newConnOptions = Object.assign({}, connOptions);
+        newConnOptions.maxAttempts -= 1;
+        return doRequest(url, headers, requestOptions, newConnOptions);
+      } else {
+        return reject({ response });
+      }
     }
     debug('Finished request');
     resolve(body);
@@ -63,12 +70,12 @@ const doRequest = (url, headers, requestOptions) => new Promise(function (resolv
 
 const LOOKUP_URL = 'https://itunes.apple.com/lookup';
 
-function lookup (ids, idField, country, requestOptions) {
+function lookup (ids, idField, country, requestOptions, connOptions) {
   idField = idField || 'id';
   country = country || 'us';
   const joinedIds = ids.join(',');
   const url = `${LOOKUP_URL}?${idField}=${joinedIds}&country=${country}&entity=software`;
-  return doRequest(url, {}, requestOptions)
+  return doRequest(url, {}, requestOptions, connOptions)
     .then(JSON.parse)
     .then((res) => res.results.filter(function (app) {
       return typeof app.wrapperType === 'undefined' || app.wrapperType === 'software';
@@ -82,4 +89,10 @@ function storeId (countryCode) {
   return (countryCode && markets[countryCode.toUpperCase()]) || defaultStore;
 }
 
-module.exports = { cleanApp, lookup, request: doRequest, storeId };
+function prepareConnOptions (opts) {
+  return {
+    maxAttempts: opts.maxAttempts
+  }
+}
+
+module.exports = { cleanApp, lookup, request: doRequest, storeId, prepareConnOptions };

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -7,7 +7,7 @@ function developer (opts) {
     if (!opts.devId) {
       throw Error('devId is required');
     }
-    resolve(common.lookup([opts.devId], 'id', opts.country, opts.requestOptions));
+    resolve(common.lookup([opts.devId], 'id', opts.country, opts.requestOptions, common.prepareConnOptions(opts)));
   })
     .then((results) => {
     // first result is artist metadata.

--- a/lib/list.js
+++ b/lib/list.js
@@ -51,7 +51,7 @@ function processResults (opts) {
 
     if (opts.fullDetail) {
       const ids = apps.map((app) => app.id.attributes['im:id']);
-      return common.lookup(ids, 'id', opts.country, opts.requestOptions);
+      return common.lookup(ids, 'id', opts.country, opts.requestOptions, prepareConnOptions(opts));
     }
 
     return apps.map(cleanApp);
@@ -84,7 +84,7 @@ function list (opts) {
     const category = opts.category ? `/genre=${opts.category}` : '';
     const storeId = common.storeId(opts.country);
     const url = `http://ax.itunes.apple.com/WebObjects/MZStoreServices.woa/ws/RSS/${opts.collection}/${category}/limit=${opts.num}/json?s=${storeId}`;
-    common.request(url, {}, opts.requestOptions)
+    common.request(url, {}, opts.requestOptions, common.prepareConnOptions(opts))
       .then(JSON.parse)
       .then(processResults(opts))
       .then(resolve)

--- a/lib/ratings.js
+++ b/lib/ratings.js
@@ -14,9 +14,9 @@ function ratings (opts) {
     const idValue = opts.id;
     const url = `https://itunes.apple.com/${country}/customer-reviews/id${idValue}?displayable-kind=11`;
 
-    resolve(common.request(url, {
-      'X-Apple-Store-Front': `${storeFront},12`
-    }));
+    resolve(common.request(
+      url, { 'X-Apple-Store-Front': `${storeFront},12` }, {}, common.prepareConnOptions(opts)
+    ));
   })
     .then((html) => {
       if (html.length === 0) {

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -47,7 +47,7 @@ const reviews = (opts) => new Promise((resolve) => {
     opts.country = opts.country || 'us';
 
     const url = `https://itunes.apple.com/${opts.country}/rss/customerreviews/page=${opts.page}/id=${id}/sortby=${opts.sort}/json`;
-    return common.request(url, {}, opts.requestOptions);
+    return common.request(url, {}, opts.requestOptions, common.prepareConnOptions(opts));
   })
   .then(JSON.parse)
   .then(cleanList);

--- a/lib/search.js
+++ b/lib/search.js
@@ -30,7 +30,8 @@ function search (opts) {
         'X-Apple-Store-Front': `${storeId},24 t:native`,
         'Accept-Language': lang
       },
-      opts.requestOptions
+      opts.requestOptions,
+      common.prepareConnOptions(opts)
     )
       .then(JSON.parse)
       .then((response) => (response.bubbles[0] && response.bubbles[0].results) || [])
@@ -38,7 +39,7 @@ function search (opts) {
       .then(R.pluck('id'))
       .then((ids) => {
         if (!opts.idsOnly) {
-          return common.lookup(ids, 'id', opts.country, opts.requestOptions);
+          return common.lookup(ids, 'id', opts.country, opts.requestOptions, common.prepareConnOptions(opts));
         }
         return ids;
       })

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -19,7 +19,8 @@ function similar (opts) {
       {
         'X-Apple-Store-Front': `${common.storeId(opts.country)},32`
       },
-      opts.requestOptions
+      opts.requestOptions,
+      common.prepareConnOptions(opts)
     ))
     .then(function (text) {
       const index = text.indexOf('customersAlsoBoughtApps');
@@ -30,7 +31,7 @@ function similar (opts) {
       const match = regExp.exec(text);
       const ids = JSON.parse(match[1]);
 
-      return common.lookup(ids, 'id', opts.country, opts.requestOptions);
+      return common.lookup(ids, 'id', opts.country, opts.requestOptions, common.prepareConnOptions(opts));
     });
 }
 

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -37,7 +37,7 @@ function suggest (opts) {
 
     return resolve(BASE_URL + encodeURIComponent(opts.term));
   })
-    .then(url => common.request(url, {}, opts.requestOptions))
+    .then(url => common.request(url, {}, opts.requestOptions, common.prepareConnOptions(opts)))
     .then(parseXML)
     .then(extractSuggestions);
 }


### PR DESCRIPTION
In order to fix "random" errors where obtaining data (#142) it is enough to repeat request a few times. This commit adds connOptions to common.doRequest() so it can be used across all requests. The opts.maxAttempts (default 1 - backward compatibility) is used to set max number of attempts before giving up. 

It might be questionable why to use common.prepareConnOptions() instead of just setting up an object. The reason is that we will like to set also time between two attempts. This is, intentionally, not part of this PR as I wish to have this as clean as possible. Also commit that will fix documentation is missing as well. 

Do I have green to implement the rest or such PR will not be accepted as it adds another layer of complexity (and should be solved in the user side for example)? Are the names of functions, parameters acceptable or should they be changed?