### PR TITLE
Add support for 'lang' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Retrieves the full detail of an application. Options:
 * `id`: the iTunes "trackId" of the app, for example `553834731` for Candy Crush Saga. Either this or the `appId` should be provided.
 * `appId`: the iTunes "bundleId" of the app, for example `com.midasplayer.apps.candycrushsaga` for Candy Crush Saga. Either this or the `id` should be provided.
 * `country`: the two letter country code to get the app details from. Defaults to `us`. Note this also affects the language of the data.
+* `lang`: language code for the result text. Defaults to undefined, so country specific language should be used automatically.
 + `ratings`: load additional ratings information like `ratings` number and `histogram`
 
 Example:
@@ -114,6 +115,7 @@ Retrieves a list of applications from one of the collections at iTunes. Options:
 * `collection`: the collection to look up. Defaults to `collection.TOP_FREE_IOS`, available options can be found [here](https://github.com/facundoolano/app-store-scraper/blob/master/lib/constants.js#L3).
 * `category`: the category to look up. This is a number associated with the genre for the application. Defaults to no specific category. Available options can be found [here](https://github.com/facundoolano/app-store-scraper/blob/master/lib/constants.js#L19).
 * `country`: the two letter country code to get the list from. Defaults to `us`.
+* `lang`: language code for the result text. Defaults to undefined, so country specific language should be used automatically.
 * `num`: the amount of elements to retrieve. Defaults to `50`, maximum
   allowed is `200`.
 * `fullDetail`: If this is set to `true`, an extra request will be
@@ -220,6 +222,7 @@ Retrieves a list of applications by the give developer id. Options:
 
 * `devId`: the iTunes "artistId" of the developer, for example `284882218` for Facebook.
 * `country`: the two letter country code to get the app details from. Defaults to `us`. Note this also affects the language of the data.
+* `lang`: language code for the result text. Defaults to undefined, so country specific language should be used automatically.
 
 Example:
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -10,7 +10,7 @@ function app (opts) {
     }
     const idField = opts.id ? 'id' : 'bundleId';
     const idValue = opts.id || opts.appId;
-    resolve(common.lookup([idValue], idField, opts.country, opts.requestOptions));
+    resolve(common.lookup([idValue], idField, opts.country, opts.lang, opts.requestOptions));
   })
     .then((results) => {
       if (results.length === 0) {

--- a/lib/common.js
+++ b/lib/common.js
@@ -63,11 +63,12 @@ const doRequest = (url, headers, requestOptions) => new Promise(function (resolv
 
 const LOOKUP_URL = 'https://itunes.apple.com/lookup';
 
-function lookup (ids, idField, country, requestOptions) {
+function lookup (ids, idField, country, lang, requestOptions) {
   idField = idField || 'id';
   country = country || 'us';
+  const langParam = lang ? `&lang=${lang}` : '';
   const joinedIds = ids.join(',');
-  const url = `${LOOKUP_URL}?${idField}=${joinedIds}&country=${country}&entity=software`;
+  const url = `${LOOKUP_URL}?${idField}=${joinedIds}&country=${country}&entity=software${langParam}`;
   return doRequest(url, {}, requestOptions)
     .then(JSON.parse)
     .then((res) => res.results.filter(function (app) {

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -7,7 +7,7 @@ function developer (opts) {
     if (!opts.devId) {
       throw Error('devId is required');
     }
-    resolve(common.lookup([opts.devId], 'id', opts.country, opts.requestOptions));
+    resolve(common.lookup([opts.devId], 'id', opts.country, opts.lang, opts.requestOptions));
   })
     .then((results) => {
     // first result is artist metadata.

--- a/lib/list.js
+++ b/lib/list.js
@@ -51,7 +51,7 @@ function processResults (opts) {
 
     if (opts.fullDetail) {
       const ids = apps.map((app) => app.id.attributes['im:id']);
-      return common.lookup(ids, 'id', opts.country, opts.requestOptions);
+      return common.lookup(ids, 'id', opts.country, opts.lang, opts.requestOptions);
     }
 
     return apps.map(cleanApp);

--- a/lib/search.js
+++ b/lib/search.js
@@ -38,7 +38,7 @@ function search (opts) {
       .then(R.pluck('id'))
       .then((ids) => {
         if (!opts.idsOnly) {
-          return common.lookup(ids, 'id', opts.country, opts.requestOptions);
+          return common.lookup(ids, 'id', opts.country, opts.lang, opts.requestOptions);
         }
         return ids;
       })

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -30,7 +30,7 @@ function similar (opts) {
       const match = regExp.exec(text);
       const ids = JSON.parse(match[1]);
 
-      return common.lookup(ids, 'id', opts.country, opts.requestOptions);
+      return common.lookup(ids, 'id', opts.country, opts.lang, opts.requestOptions);
     });
 }
 


### PR DESCRIPTION
In some cases, it is required to use "lang" param together with "country" to obtain text in the local
language. Without the "lang" parameter, text defaults to English e.g. in Slovakia (sk) . This commit attempts to not change existing working URL if opts.lang is not set. 

