### PR TITLE
force updgraded ramda and added launch.json debugging to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Local Debugging
+launch.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1693,7 +1693,7 @@
     "ramda": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
-      "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU="
+      "integrity": "sha512-HGd5aczYKQXGILB+abY290V7Xz62eFajpa6AtMdwEmQSakJmgSO7ks4eI3HdR34j+X2Vz4Thp9VAJbrCAMbO2w=="
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -1974,6 +1974,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "throttled-request": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/throttled-request/-/throttled-request-0.1.1.tgz",
+      "integrity": "sha1-QUa3C3elrsozxGMyzxPrnHkelxs="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cheerio": "^1.0.0-rc.2",
     "debug": "^2.2.0",
     "memoizee": "^0.3.10",
-    "ramda": "^0.21.0",
+    "ramda": "^0.27.2",
     "request": "^2.87.0",
     "throttled-request": "^0.1.1",
     "xml2js": "^0.4.16"


### PR DESCRIPTION
SNYK found some issues with Ramda 0.2~ that was used and said 0.27.2 should be used to fix it.
I couldn't fix all the tests because they have to do with changes in implementation of this package and AppStore/Google Play, but at least the same amount of tests were working before and after the fix.
I've attached a screenshots of the SNYK reported issue

<img width="1435" alt="Screen Shot 2022-06-09 at 11 19 55 AM" src="https://user-images.githubusercontent.com/20052730/172812857-688f43f0-6da3-4a3b-bd0a-2ecb2b15087c.png">

<img width="1407" alt="Screen Shot 2022-06-09 at 11 20 14 AM" src="https://user-images.githubusercontent.com/20052730/172812926-94de1043-69e4-49e4-b578-15b

<img width="1404" alt="Screen Shot 2022-06-09 at 11 20 35 AM" src="https://user
<img width="1405" alt="Screen Shot 2022-06-09 at 11 21 13 AM" src="https://user-images.githubusercontent.com/20052730/172813147-017d7383-3ff9-49fc-85c9-f291a1f135da.png">

-images.githubusercontent.com/20052730/172813005-875b5f25-7ccf-4c73-a5d1-a99e0a374c43.png">
bacc9d4b8.png">
.