### PR TITLE
Fix/privacy country codes

### DIFF
--- a/lib/privacy.js
+++ b/lib/privacy.js
@@ -11,7 +11,7 @@ function privacy (opts) {
     }
   })
     .then(() => {
-      const tokenUrl = `https://apps.apple.com/us/app/id${opts.id}`;
+      const tokenUrl = `https://apps.apple.com/${opts.country}/app/id${opts.id}`;
       return common.request(tokenUrl, {}, opts.requestOptions);
     })
     .then((html) => {
@@ -19,7 +19,7 @@ function privacy (opts) {
       const match = regExp.exec(html);
       const token = match[1];
 
-      const url = `https://amp-api.apps.apple.com/v1/catalog/US/apps/${opts.id}?platform=web&fields=privacyDetails&l=en-us`;
+      const url = `https://amp-api.apps.apple.com/v1/catalog/${opts.country}/apps/${opts.id}?platform=web&fields=privacyDetails`;
       return common.request(url, {
         'Origin': 'https://apps.apple.com',
         'Authorization': `Bearer ${token}`
@@ -33,3 +33,4 @@ function privacy (opts) {
 }
 
 module.exports = privacy;
+

--- a/lib/privacy.js
+++ b/lib/privacy.js
@@ -3,6 +3,8 @@
 const common = require('./common');
 
 function privacy (opts) {
+  opts.country = opts.country || 'US';
+
   return new Promise((resolve) => {
     if (opts.id) {
       resolve();


### PR DESCRIPTION
If no country code is specified for the `privacy` option for an app id that refers to an non-US instance, `privacy` will return 404. Specifying the right country fixes the problem.