### PR TITLE
Added privacyPolicyUrl support to store.privacy function supporting all countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ Returns:
       "purposes": []
     },
     ...
-  ]
+  ],
+  "privacyPolicyUrl": "https://king.com/privacyPolicy"
 }
 ```
 

--- a/lib/privacy.js
+++ b/lib/privacy.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('./common');
+const cheerio = require('cheerio');
 
 function privacy (opts) {
   opts.country = opts.country || 'US';
@@ -21,18 +22,30 @@ function privacy (opts) {
       const match = regExp.exec(html);
       const token = match[1];
 
+      const privacyPolicyUrl = extractPrivacyPolicyUrl(html);
+
       const url = `https://amp-api.apps.apple.com/v1/catalog/${opts.country}/apps/${opts.id}?platform=web&fields=privacyDetails`;
       return common.request(url, {
         'Origin': 'https://apps.apple.com',
         'Authorization': `Bearer ${token}`
-      }, opts.requestOptions);
+      }, opts.requestOptions).then((json) => ({ json, privacyPolicyUrl }));
     })
-    .then((json) => {
-      if (json.length === 0) { throw Error('App not found (404)'); }
-
-      return JSON.parse(json).data[0].attributes.privacyDetails;
+    .then(({ json, privacyPolicyUrl }) => {
+      if (json.length === 0) {
+        throw Error('App not found (404)');
+      }
+      
+      const privacyDetails = JSON.parse(json).data[0].attributes.privacyDetails;
+      return { ...privacyDetails, privacyPolicyUrl };
     });
 }
 
 module.exports = privacy;
 
+
+function extractPrivacyPolicyUrl(html) {
+  const $ = cheerio.load(html);
+  const privacyPolicyUrl = $('span.app-privacy__developer-name').closest('p').find('a[href]').attr('href');
+  
+  return privacyPolicyUrl || null;
+}


### PR DESCRIPTION
This was missing and not available in `itunes lookup` or `amp-api` 

- How it's being done here : extracted from same html using cheerio while `tokenUrl` is requested, from parent of span tag as mentioned in function `extractPrivacyPolicyUrl`, and passing to main object while return.

- Supports all categories as this tag won't change for diff countries, content may.

Examples: 
US:
```
{
  managePrivacyChoicesUrl: null,
  privacyTypes: [
    {
      privacyType: 'Data Used to Track You',
      identifier: 'DATA_USED_TO_TRACK_YOU',
      description: 'The following data may be used to track you across apps and websites owned by other companies:',
      dataCategories: [Array],
      purposes: []
    },
    {
      privacyType: 'Data Linked to You',
      identifier: 'DATA_LINKED_TO_YOU',
      description: 'The following data, which may be collected and linked to your identity, may be used for the following purposes:',
      dataCategories: [],
      purposes: [Array]
    }
  ],
  privacyPolicyUrl: 'https://king.com/privacyPolicy'
}
```

FR:
```
{
  managePrivacyChoicesUrl: null,
  privacyTypes: [
    {
      privacyType: 'Données utilisées pour vous suivre',
      identifier: 'DATA_USED_TO_TRACK_YOU',
      description: 'Les données suivantes peuvent être utilisées pour vous suivre dans plusieurs apps et sites web appartenant à d’autres sociétés :',
      dataCategories: [Array],
      purposes: []
    },
    {
      privacyType: 'Données établissant un lien avec vous',
      identifier: 'DATA_LINKED_TO_YOU',
      description: 'Les données suivantes, pouvant être collectées et liées à votre identité, peuvent être utilisées aux fins suivantes :',
      dataCategories: [],
      purposes: [Array]
    }
  ],
  privacyPolicyUrl: 'http://king.com/fr/privacyPolicy'
}
```

JP:
```
{
  managePrivacyChoicesUrl: null,
  privacyTypes: [
    {
      privacyType: 'Données utilisées pour vous suivre',
      identifier: 'DATA_USED_TO_TRACK_YOU',
      description: 'Les données suivantes peuvent être utilisées pour vous suivre dans plusieurs apps et sites web appartenant à d’autres sociétés :',
      dataCategories: [Array],
      purposes: []
    },
    {
      privacyType: 'Données établissant un lien avec vous',
      identifier: 'DATA_LINKED_TO_YOU',
      description: 'Les données suivantes, pouvant être collectées et liées à votre identité, peuvent être utilisées aux fins suivantes :',
      dataCategories: [],
      purposes: [Array]
    }
  ],
  privacyPolicyUrl: 'http://king.com/fr/privacyPolicy'
}
```